### PR TITLE
Revert "#4"

### DIFF
--- a/main/core/apps/settings/SettingsCommon.hpp
+++ b/main/core/apps/settings/SettingsCommon.hpp
@@ -77,27 +77,4 @@ inline void add_switch_item(lv_obj_t* list, const char* text, lv_subject_t* subj
 	lv_obj_bind_checked(sw, subject);
 }
 
-inline lv_obj_t* add_slider_item(lv_obj_t* list, const char* text, lv_subject_t* subject, int32_t min_val, int32_t max_val) {
-	lv_obj_t* btn = lv_list_add_button(list, nullptr, text);
-	lv_obj_set_flex_flow(btn, LV_FLEX_FLOW_ROW);
-	lv_obj_set_flex_align(btn, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-
-	lv_obj_t* slider = lv_slider_create(btn);
-	lv_slider_set_range(slider, min_val, max_val);
-	lv_obj_set_flex_grow(slider, 1);
-	lv_slider_bind_value(slider, subject);
-
-	lv_obj_t* value_label = lv_label_create(btn);
-	lv_label_set_text_fmt(value_label, "%ld", lv_subject_get_int(subject));
-	lv_obj_set_style_min_width(value_label, lv_dpx(UiConstants::PAD_LARGE), 0);
-
-	// Update label when slider changes
-	lv_obj_add_event_cb(slider, [](lv_event_t* e) {
-		auto* label = (lv_obj_t*)lv_event_get_user_data(e);
-		auto* slider_obj = lv_event_get_target_obj(e);
-		lv_label_set_text_fmt(label, "%ld", lv_slider_get_value(slider_obj)); }, LV_EVENT_VALUE_CHANGED, value_label);
-
-	return slider;
-}
-
 } // namespace System::Apps::Settings

--- a/main/core/apps/settings/hotspot/HotspotSettings.cpp
+++ b/main/core/apps/settings/hotspot/HotspotSettings.cpp
@@ -418,17 +418,23 @@ void HotspotSettings::createConfigPage() {
 	lv_obj_set_style_pad_all(maxConnCont, 0, 0);
 	lv_obj_set_style_border_width(maxConnCont, 0, 0);
 	lv_obj_set_flex_flow(maxConnCont, LV_FLEX_FLOW_ROW);
-	lv_obj_set_flex_align(maxConnCont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+	lv_obj_set_flex_align(maxConnCont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 	lv_obj_t* maxConnLabel = lv_label_create(maxConnCont);
 	lv_label_set_text(maxConnLabel, "Max Connections:");
-	m_maxConnSlider = lv_slider_create(maxConnCont);
-	lv_obj_set_flex_grow(m_maxConnSlider, 1);
+	lv_obj_t* sliderCont = lv_obj_create(maxConnCont);
+	lv_obj_set_size(sliderCont, lv_pct(100), LV_SIZE_CONTENT);
+	lv_obj_set_style_pad_all(sliderCont, 0, 0);
+	lv_obj_set_style_border_width(sliderCont, 0, 0);
+	lv_obj_set_flex_flow(sliderCont, LV_FLEX_FLOW_COLUMN);
+	m_maxConnSlider = lv_slider_create(sliderCont);
 	lv_slider_set_range(m_maxConnSlider, 1, 10);
 	int const saved_max = lv_subject_get_int(&ConnectivityManager::getInstance().getHotspotMaxConnSubject());
 	lv_slider_set_value(m_maxConnSlider, saved_max > 0 ? saved_max : 4, LV_ANIM_OFF);
-	lv_obj_t* maxConnValLabel = lv_label_create(maxConnCont);
+	lv_obj_set_width(m_maxConnSlider, lv_pct(100));
+	lv_obj_t* maxConnValLabel = lv_label_create(sliderCont);
 	lv_label_set_text_fmt(maxConnValLabel, "%d", saved_max > 0 ? saved_max : 4);
-	lv_obj_set_width(maxConnValLabel, LV_SIZE_CONTENT);
+	lv_obj_set_style_text_align(maxConnValLabel, LV_TEXT_ALIGN_CENTER, 0);
+	lv_obj_set_width(maxConnValLabel, lv_pct(100));
 	lv_obj_add_event_cb(
 		m_maxConnSlider,
 		[](lv_event_t* e) {
@@ -488,16 +494,22 @@ void HotspotSettings::createConfigPage() {
 	lv_obj_set_style_pad_all(txCont, 0, 0);
 	lv_obj_set_style_border_width(txCont, 0, 0);
 	lv_obj_set_flex_flow(txCont, LV_FLEX_FLOW_ROW);
-	lv_obj_set_flex_align(txCont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+	lv_obj_set_flex_align(txCont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 	lv_obj_t* txLabel = lv_label_create(txCont);
 	lv_label_set_text(txLabel, "TX Power:");
-	m_txPowerSlider = lv_slider_create(txCont);
-	lv_obj_set_flex_grow(m_txPowerSlider, 1);
+	lv_obj_t* txSliderCont = lv_obj_create(txCont);
+	lv_obj_set_size(txSliderCont, lv_pct(100), LV_SIZE_CONTENT);
+	lv_obj_set_style_pad_all(txSliderCont, 0, 0);
+	lv_obj_set_style_border_width(txSliderCont, 0, 0);
+	lv_obj_set_flex_flow(txSliderCont, LV_FLEX_FLOW_COLUMN);
+	m_txPowerSlider = lv_slider_create(txSliderCont);
 	lv_slider_set_range(m_txPowerSlider, 8, 80);
 	lv_slider_set_value(m_txPowerSlider, 80, LV_ANIM_OFF);
-	lv_obj_t* txValLabel = lv_label_create(txCont);
+	lv_obj_set_width(m_txPowerSlider, lv_pct(100));
+	lv_obj_t* txValLabel = lv_label_create(txSliderCont);
 	lv_label_set_text(txValLabel, "80");
-	lv_obj_set_width(txValLabel, LV_SIZE_CONTENT);
+	lv_obj_set_style_text_align(txValLabel, LV_TEXT_ALIGN_CENTER, 0);
+	lv_obj_set_width(txValLabel, lv_pct(100));
 	lv_obj_add_event_cb(
 		m_txPowerSlider,
 		[](lv_event_t* e) {

--- a/main/core/apps/settings/wifi/WiFiSettings.cpp
+++ b/main/core/apps/settings/wifi/WiFiSettings.cpp
@@ -20,6 +20,7 @@
 #include "layouts/flex/lv_flex.h"
 #include "misc/lv_area.h"
 #include "misc/lv_event.h"
+#include "misc/lv_timer.h"
 #include "misc/lv_types.h"
 #include "widgets/button/lv_button.h"
 #include "widgets/image/lv_image.h"
@@ -79,21 +80,7 @@ void WiFiSettings::show() {
 					lv_obj_clean(instance->m_list);
 					lv_list_add_text(instance->m_list, "Wi-Fi is disabled");
 				} else {
-					// Auto-connect to saved network if available
-					auto& cm = ConnectivityManager::getInstance();
-					if (cm.hasSavedWiFiCredentials()) {
-						cm.connectWiFi(
-							cm.getSavedWiFiSsid(),
-							cm.getSavedWiFiPassword(),
-							false // Don't re-save, already saved
-						);
-						// Mark pending auto-scan for when connection completes
-						instance->m_pendingAutoScan = true;
-						lv_obj_clean(instance->m_list);
-						lv_list_add_text(instance->m_list, "Connecting to saved network...");
-					} else {
-						instance->refreshScan();
-					}
+					instance->refreshScan();
 				}
 				instance->updateStatus();
 			},
@@ -132,88 +119,20 @@ void WiFiSettings::show() {
 
 		m_list = create_settings_list(m_container);
 
-		// Observer for WiFi status changes - triggers auto-scan after connection
-		m_statusObserver = lv_subject_add_observer_obj(
-			&ConnectivityManager::getInstance().getWiFiConnectedSubject(),
-			[](lv_observer_t* observer, lv_subject_t* subject) {
-				auto* instance = (WiFiSettings*)lv_observer_get_user_data(observer);
-				int32_t connected = lv_subject_get_int(subject);
-				if (connected && instance->m_pendingAutoScan) {
-					instance->m_pendingAutoScan = false;
-					instance->refreshScan();
-				}
+		m_timer = lv_timer_create(
+			[](lv_timer_t* t) {
+				auto* instance = (WiFiSettings*)lv_timer_get_user_data(t);
 				instance->updateStatus();
 			},
-			m_container, this
+			1000, this
 		);
-
-		// Observer for scan interval setting changes
-		m_scanIntervalObserver = lv_subject_add_observer_obj(
-			&ConnectivityManager::getInstance().getWiFiScanIntervalSubject(),
-			[](lv_observer_t* observer, lv_subject_t* subject) {
-				auto* instance = (WiFiSettings*)lv_observer_get_user_data(observer);
-				int32_t interval = lv_subject_get_int(subject);
-
-				// Delete existing timer if any
-				if (instance->m_scanTimer != nullptr) {
-					esp_timer_stop(instance->m_scanTimer);
-					esp_timer_delete(instance->m_scanTimer);
-					instance->m_scanTimer = nullptr;
-				}
-
-				// Create new timer if interval > 0
-				if (interval > 0) {
-					esp_timer_create_args_t timer_args = {
-						.callback = [](void* arg) {
-							auto* inst = static_cast<WiFiSettings*>(arg);
-							GuiTask::lock();
-							bool should_scan = ConnectivityManager::getInstance().isWiFiEnabled() && !inst->m_isScanning;
-							GuiTask::unlock();
-							if (should_scan) {
-								GuiTask::lock();
-								inst->refreshScan();
-								GuiTask::unlock();
-							}
-						},
-						.arg = instance,
-						.dispatch_method = ESP_TIMER_TASK,
-						.name = "wifi_scan_timer",
-						.skip_unhandled_events = true,
-					};
-					esp_timer_create(&timer_args, &instance->m_scanTimer);
-					esp_timer_start_periodic(instance->m_scanTimer, static_cast<uint64_t>(interval) * 1000000);
-				}
-			},
-			m_container, this
-		);
-
-		// Trigger initial timer setup based on current setting
-		int32_t initial_interval = lv_subject_get_int(&ConnectivityManager::getInstance().getWiFiScanIntervalSubject());
-		if (initial_interval > 0) {
-			esp_timer_create_args_t timer_args = {
-				.callback = [](void* arg) {
-					auto* inst = static_cast<WiFiSettings*>(arg);
-					GuiTask::lock();
-					bool should_scan = ConnectivityManager::getInstance().isWiFiEnabled() && !inst->m_isScanning;
-					GuiTask::unlock();
-					if (should_scan) {
-						GuiTask::lock();
-						inst->refreshScan();
-						GuiTask::unlock();
-					}
-				},
-				.arg = this,
-				.dispatch_method = ESP_TIMER_TASK,
-				.name = "wifi_scan_timer",
-				.skip_unhandled_events = true,
-			};
-			esp_timer_create(&timer_args, &m_scanTimer);
-			esp_timer_start_periodic(m_scanTimer, static_cast<uint64_t>(initial_interval) * 1000000);
-		}
 
 		refreshScan();
 	} else {
 		lv_obj_remove_flag(m_container, LV_OBJ_FLAG_HIDDEN);
+		if (m_timer) {
+			lv_timer_resume(m_timer);
+		}
 		updateStatus();
 		refreshScan();
 	}
@@ -241,14 +160,6 @@ void WiFiSettings::showConfig() {
 		list,
 		"Auto-start on Boot",
 		&ConnectivityManager::getInstance().getWiFiAutostartSubject()
-	);
-
-	// Auto-scan interval slider (0 = disabled, 10-120 seconds)
-	add_slider_item(
-		list,
-		"Scan Interval (s)",
-		&ConnectivityManager::getInstance().getWiFiScanIntervalSubject(),
-		0, 120 // 0 = disabled, max 2 minutes
 	);
 }
 
@@ -434,7 +345,6 @@ void WiFiSettings::showConnectScreen(const char* ssid) {
 	lv_obj_set_flex_flow(btnCont, LV_FLEX_FLOW_ROW);
 	lv_obj_set_flex_align(btnCont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 	lv_obj_set_style_pad_gap(btnCont, lv_dpx(UiConstants::PAD_MEDIUM), 0);
-	lv_obj_remove_flag(btnCont, LV_OBJ_FLAG_SCROLLABLE);
 
 	lv_obj_t* cancelBtn = lv_button_create(btnCont);
 	lv_obj_t* cancelLabel = lv_label_create(cancelBtn);
@@ -446,10 +356,26 @@ void WiFiSettings::showConnectScreen(const char* ssid) {
 			lv_obj_delete(instance->m_connectContainer);
 			instance->m_connectContainer = nullptr;
 			instance->m_passwordTa = nullptr;
-			instance->m_saveSwitch = nullptr;
+			instance->m_rememberSwitch = nullptr;
 		},
 		LV_EVENT_CLICKED, this
 	);
+
+	// Remember switch container
+	lv_obj_t* remember_cont = lv_obj_create(btnCont);
+	lv_obj_set_size(remember_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+	lv_obj_set_style_pad_all(remember_cont, 0, 0);
+	lv_obj_set_style_border_width(remember_cont, 0, 0);
+	lv_obj_set_style_bg_opa(remember_cont, 0, 0);
+	lv_obj_set_flex_flow(remember_cont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(remember_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+	lv_obj_set_style_pad_gap(remember_cont, lv_dpx(UiConstants::PAD_SMALL), 0);
+
+	lv_obj_t* remember_label = lv_label_create(remember_cont);
+	lv_label_set_text(remember_label, "Remember");
+
+	m_rememberSwitch = lv_switch_create(remember_cont);
+	lv_obj_add_state(m_rememberSwitch, LV_STATE_CHECKED); // Default to remember
 
 	lv_obj_t* connectBtn = lv_button_create(btnCont);
 	lv_obj_t* connectLabel = lv_label_create(connectBtn);
@@ -459,33 +385,18 @@ void WiFiSettings::showConnectScreen(const char* ssid) {
 		[](lv_event_t* e) {
 			auto* instance = (WiFiSettings*)lv_event_get_user_data(e);
 			const char* password = lv_textarea_get_text(instance->m_passwordTa);
-			bool save = lv_obj_has_state(instance->m_saveSwitch, LV_STATE_CHECKED);
+			bool remember = lv_obj_has_state(instance->m_rememberSwitch, LV_STATE_CHECKED);
 			ConnectivityManager::getInstance().connectWiFi(
-				instance->m_connectSsid.c_str(), password, save
+				instance->m_connectSsid.c_str(), password, remember
 			);
 			lv_obj_delete(instance->m_connectContainer);
 			instance->m_connectContainer = nullptr;
 			instance->m_passwordTa = nullptr;
-			instance->m_saveSwitch = nullptr;
+			instance->m_rememberSwitch = nullptr;
 			instance->updateStatus();
 		},
 		LV_EVENT_CLICKED, this
 	);
-
-	// Save switch container
-	lv_obj_t* save_cont = lv_obj_create(m_connectContainer);
-	lv_obj_set_size(save_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-	lv_obj_set_style_pad_all(save_cont, 0, 0);
-	lv_obj_set_style_border_width(save_cont, 0, 0);
-	lv_obj_set_flex_flow(save_cont, LV_FLEX_FLOW_ROW);
-	lv_obj_set_flex_align(save_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-	lv_obj_set_style_pad_gap(save_cont, lv_dpx(UiConstants::PAD_SMALL), 0);
-
-	lv_obj_t* save_label = lv_label_create(save_cont);
-	lv_label_set_text(save_label, "Save");
-
-	m_saveSwitch = lv_switch_create(save_cont);
-	lv_obj_add_state(m_saveSwitch, LV_STATE_CHECKED); // Default to save
 
 	lv_obj_add_state(m_passwordTa, LV_STATE_FOCUSED);
 }
@@ -493,6 +404,9 @@ void WiFiSettings::showConnectScreen(const char* ssid) {
 void WiFiSettings::hide() {
 	if (m_container) {
 		lv_obj_add_flag(m_container, LV_OBJ_FLAG_HIDDEN);
+	}
+	if (m_timer) {
+		lv_timer_pause(m_timer);
 	}
 	if (m_connectContainer) {
 		lv_obj_delete(m_connectContainer);
@@ -502,10 +416,9 @@ void WiFiSettings::hide() {
 }
 
 void WiFiSettings::destroy() {
-	if (m_scanTimer != nullptr) {
-		esp_timer_stop(m_scanTimer);
-		esp_timer_delete(m_scanTimer);
-		m_scanTimer = nullptr;
+	if (m_timer) {
+		lv_timer_delete(m_timer);
+		m_timer = nullptr;
 	}
 	if (m_connectContainer) {
 		lv_obj_delete(m_connectContainer);
@@ -517,9 +430,7 @@ void WiFiSettings::destroy() {
 	m_wifiSwitch = nullptr;
 	m_statusLabel = nullptr;
 	m_statusPrefixLabel = nullptr;
-	m_saveSwitch = nullptr;
-	m_statusObserver = nullptr; // Auto-cleaned when m_container is deleted
-	m_scanIntervalObserver = nullptr; // Auto-cleaned when m_container is deleted
+	m_rememberSwitch = nullptr;
 }
 
 } // namespace System::Apps::Settings

--- a/main/core/apps/settings/wifi/WiFiSettings.hpp
+++ b/main/core/apps/settings/wifi/WiFiSettings.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "esp_timer.h"
 #include "esp_wifi.h"
 #include "lvgl.h"
 #include <cstring>
@@ -36,13 +35,10 @@ private:
 	lv_obj_t* m_statusLabel = nullptr;
 	lv_obj_t* m_statusPrefixLabel = nullptr;
 	lv_obj_t* m_passwordTa = nullptr;
-	lv_obj_t* m_saveSwitch = nullptr;
+	lv_obj_t* m_rememberSwitch = nullptr;
 	std::string m_connectSsid {};
+	lv_timer_t* m_timer = nullptr;
 	bool m_isScanning = false;
-	bool m_pendingAutoScan = false;
-	lv_observer_t* m_statusObserver = nullptr;
-	lv_observer_t* m_scanIntervalObserver = nullptr;
-	esp_timer_handle_t m_scanTimer = nullptr;
 	std::function<void()> m_onBack {};
 	std::vector<wifi_ap_record_t> m_scanResults {};
 };

--- a/main/core/connectivity/ConnectivityManager.cpp
+++ b/main/core/connectivity/ConnectivityManager.cpp
@@ -46,7 +46,6 @@ esp_err_t ConnectivityManager::init() {
 	SettingsManager::getInstance().registerSetting("hs_hide", m_hotspot_hidden_subject);
 	SettingsManager::getInstance().registerSetting("hs_auth", m_hotspot_auth_subject);
 	SettingsManager::getInstance().registerSetting("wifi_autostart", m_wifi_autostart_subject);
-	SettingsManager::getInstance().registerSetting("wifi_scan_int", m_wifi_scan_interval_subject);
 	SettingsManager::getInstance().registerSetting("wifi_ssid", m_saved_wifi_ssid_subject);
 	SettingsManager::getInstance().registerSetting("wifi_pass", m_saved_wifi_password_subject);
 
@@ -95,7 +94,6 @@ void ConnectivityManager::initGuiBridges() {
 	m_hotspot_hidden_bridge = std::make_unique<LvglObserverBridge<int32_t>>(m_hotspot_hidden_subject);
 	m_hotspot_auth_bridge = std::make_unique<LvglObserverBridge<int32_t>>(m_hotspot_auth_subject);
 	m_wifi_autostart_bridge = std::make_unique<LvglObserverBridge<int32_t>>(m_wifi_autostart_subject);
-	m_wifi_scan_interval_bridge = std::make_unique<LvglObserverBridge<int32_t>>(m_wifi_scan_interval_subject);
 }
 #endif
 

--- a/main/core/connectivity/ConnectivityManager.hpp
+++ b/main/core/connectivity/ConnectivityManager.hpp
@@ -41,8 +41,6 @@ public:
 	void saveWiFiCredentials(const char* ssid, const char* password);
 	void clearSavedWiFiCredentials();
 	bool hasSavedWiFiCredentials() const;
-	const char* getSavedWiFiSsid() const { return m_saved_wifi_ssid_subject.get(); }
-	const char* getSavedWiFiPassword() const { return m_saved_wifi_password_subject.get(); }
 
 	// WiFi Hotspot (SoftAP)
 	esp_err_t startHotspot(const char* ssid, const char* password, int channel = 1, int max_connections = 4, bool hidden = false, wifi_auth_mode_t auth_mode = WIFI_AUTH_WPA2_PSK, int8_t max_tx_power = 80);
@@ -87,7 +85,6 @@ public:
 	Observable<int32_t>& getHotspotHiddenObservable() { return m_hotspot_hidden_subject; }
 	Observable<int32_t>& getHotspotAuthObservable() { return m_hotspot_auth_subject; }
 	Observable<int32_t>& getWiFiAutostartObservable() { return m_wifi_autostart_subject; }
-	Observable<int32_t>& getWiFiScanIntervalObservable() { return m_wifi_scan_interval_subject; }
 	StringObservable& getSavedWiFiSsidObservable() { return m_saved_wifi_ssid_subject; }
 	StringObservable& getSavedWiFiPasswordObservable() { return m_saved_wifi_password_subject; }
 
@@ -114,7 +111,6 @@ public:
 	lv_subject_t& getHotspotHiddenSubject() { return *m_hotspot_hidden_bridge->getSubject(); }
 	lv_subject_t& getHotspotAuthSubject() { return *m_hotspot_auth_bridge->getSubject(); }
 	lv_subject_t& getWiFiAutostartSubject() { return *m_wifi_autostart_bridge->getSubject(); }
-	lv_subject_t& getWiFiScanIntervalSubject() { return *m_wifi_scan_interval_bridge->getSubject(); }
 #endif
 
 private:
@@ -147,7 +143,6 @@ private:
 	Observable<int32_t> m_hotspot_hidden_subject {0};
 	Observable<int32_t> m_hotspot_auth_subject {1};
 	Observable<int32_t> m_wifi_autostart_subject {0};
-	Observable<int32_t> m_wifi_scan_interval_subject {0}; // 0 = disabled, otherwise seconds
 	StringObservable m_saved_wifi_ssid_subject {""};
 	StringObservable m_saved_wifi_password_subject {""};
 
@@ -174,7 +169,6 @@ private:
 	std::unique_ptr<LvglObserverBridge<int32_t>> m_hotspot_hidden_bridge {};
 	std::unique_ptr<LvglObserverBridge<int32_t>> m_hotspot_auth_bridge {};
 	std::unique_ptr<LvglObserverBridge<int32_t>> m_wifi_autostart_bridge {};
-	std::unique_ptr<LvglObserverBridge<int32_t>> m_wifi_scan_interval_bridge {};
 #endif
 
 	bool m_is_init = false;

--- a/main/core/connectivity/wifi/WiFiManager.hpp
+++ b/main/core/connectivity/wifi/WiFiManager.hpp
@@ -4,7 +4,6 @@
 #include "esp_err.h"
 #include "esp_event.h"
 #include "esp_wifi.h"
-#include <atomic>
 #include <functional>
 #include <vector>
 
@@ -65,7 +64,7 @@ private:
 
 	bool m_is_init = false;
 	bool m_is_enabled = false;
-	std::atomic<bool> m_is_scanning {false};
+	bool m_is_scanning = false;
 	bool m_should_reconnect = false;
 	int m_retry_count = 0;
 	static constexpr int MAX_RETRIES = 5;

--- a/main/core/system/theme/ThemeManager.cpp
+++ b/main/core/system/theme/ThemeManager.cpp
@@ -22,11 +22,6 @@ void ThemeManager::init() {
 	SettingsManager::getInstance().registerSetting("wp_enabled", m_wallpaper_enabled_subject);
 	SettingsManager::getInstance().registerSetting("wp_path", m_wallpaper_path_subject);
 
-	// Set default wallpaper path if not already set
-	if (strlen(m_wallpaper_path_subject.get()) == 0) {
-		m_wallpaper_path_subject.set(DEFAULT_WALLPAPER_PATH);
-	}
-
 	// Initial application
 	applyTheme(m_theme_subject.get());
 }
@@ -40,7 +35,7 @@ void ThemeManager::initGuiBridges() {
 	m_wallpaper_enabled_bridge = std::make_unique<LvglObserverBridge<int32_t>>(m_wallpaper_enabled_subject);
 	m_wallpaper_path_bridge = std::make_unique<LvglStringObserverBridge>(m_wallpaper_path_subject);
 
-	lv_subject_add_observer(m_theme_bridge->getSubject(), [](lv_observer_t*, lv_subject_t* s) { ThemeManager::applyTheme(lv_subject_get_int(s)); }, nullptr);
+	lv_subject_add_observer(m_theme_bridge->getSubject(), [](lv_observer_t*, lv_subject_t* s) { ThemeManager::getInstance().applyTheme(lv_subject_get_int(s)); }, nullptr);
 
 	// Initial application to GUI
 	applyTheme(m_theme_subject.get());

--- a/main/core/system/theme/ThemeManager.hpp
+++ b/main/core/system/theme/ThemeManager.hpp
@@ -14,8 +14,6 @@ namespace System {
 class ThemeManager {
 public:
 
-	static constexpr const char* DEFAULT_WALLPAPER_PATH = "A:/data/wallpaper.jpg";
-
 	static ThemeManager& getInstance();
 
 	void init();

--- a/main/core/ui/desktop/Desktop.cpp
+++ b/main/core/ui/desktop/Desktop.cpp
@@ -17,7 +17,6 @@
 #include "core/ui/theming/themes/Themes.hpp"
 #include "display/lv_display.h"
 #include "font/lv_symbol_def.h"
-#include "misc/cache/instance/lv_image_cache.h"
 #include "misc/lv_area.h"
 #include "misc/lv_event.h"
 #include "misc/lv_types.h"
@@ -102,7 +101,7 @@ void Desktop::init() {
 						if (path && strlen(path) > 0) {
 							lv_image_set_src(instance->m_wallpaper_img, path);
 						} else {
-							lv_image_set_src(instance->m_wallpaper_img, System::ThemeManager::DEFAULT_WALLPAPER_PATH);
+							lv_image_set_src(instance->m_wallpaper_img, "A:/data/wallpaper.jpg");
 						}
 						lv_obj_set_size(instance->m_wallpaper_img, lv_pct(100), lv_pct(100));
 						lv_obj_set_style_pad_all(instance->m_wallpaper_img, 0, 0);
@@ -115,7 +114,6 @@ void Desktop::init() {
 						lv_obj_remove_flag(instance->m_wallpaper_icon, LV_OBJ_FLAG_HIDDEN);
 					}
 					if (instance->m_wallpaper_img != nullptr) {
-						lv_image_cache_drop(lv_image_get_src(instance->m_wallpaper_img));
 						lv_obj_delete(instance->m_wallpaper_img);
 						instance->m_wallpaper_img = nullptr;
 					}
@@ -129,12 +127,8 @@ void Desktop::init() {
 			[](lv_observer_t* observer, lv_subject_t* subject) {
 				auto* instance = (Desktop*)lv_observer_get_user_data(observer);
 				const char* path = (const char*)lv_subject_get_pointer(subject);
-				if (instance->m_wallpaper_img) {
-					if (path && strlen(path) > 0) {
-						lv_image_set_src(instance->m_wallpaper_img, path);
-					} else {
-						lv_image_set_src(instance->m_wallpaper_img, System::ThemeManager::DEFAULT_WALLPAPER_PATH);
-					}
+				if (instance->m_wallpaper_img && path && strlen(path) > 0) {
+					lv_image_set_src(instance->m_wallpaper_img, path);
 				}
 			},
 			this

--- a/main/core/ui/theming/layout_constants/LayoutConstants.hpp
+++ b/main/core/ui/theming/layout_constants/LayoutConstants.hpp
@@ -21,7 +21,7 @@ static constexpr int DOCK_BTN_HEIGHT_SMALL_PCT = 80;
 // Fixed Pixel Sizes (Logic Units - use with lv_dpx)
 static constexpr int SIZE_TOUCH_TARGET = 30;
 static constexpr int SIZE_DROPDOWN_WIDTH_SMALL = 80;
-static constexpr int SIZE_DROPDOWN_WIDTH_LARGE = 160;
+static constexpr int SIZE_DROPDOWN_WIDTH_LARGE = 125;
 static constexpr int SIZE_DROPDOWN_HEIGHT = 35;
 static constexpr int SIZE_DROPDOWN_BTN_WIDTH = 40;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts Wi‑Fi auto‑connect and auto‑scan features to restore manual scanning and a simpler settings UI. Also cleans up theme defaults and tightens some UI layouts.

- **Refactors**
  - Reverted Wi‑Fi auto‑connect and scan interval; status updates now use a lightweight lv_timer.
  - Removed Wi‑Fi scan interval setting, subjects/bridges, and esp_timer logic in ConnectivityManager/WiFiSettings.
  - Simplified connect flow with a “Remember” switch; removed saved SSID/password accessors.
  - Dropped the shared slider helper; hotspot sliders use a local container with centered value labels.
  - Simplified WiFiManager scanning state (atomic -> bool), hard‑coded wallpaper fallback path, and reduced large dropdown width to 125.

<sup>Written for commit ebf196966c93ccf76a5a2ae75d7de6e19bb28272. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

