### PR TITLE
fix: Remove ineffective image_recolor calls from apply_glass utility

### DIFF
--- a/main/core/ui/theming/StyleUtils.hpp
+++ b/main/core/ui/theming/StyleUtils.hpp
@@ -13,8 +13,6 @@ static inline void apply_glass(lv_obj_t* obj, int32_t blur) {
 	lv_obj_set_style_bg_color(obj, cfg.surface, 0);
 	lv_obj_set_style_bg_opa(obj, UiConstants::OPA_GLASS_BG, 0);
 	lv_obj_set_style_text_color(obj, cfg.text_primary, 0);
-	lv_obj_set_style_image_recolor(obj, cfg.text_primary, 0);
-	lv_obj_set_style_image_recolor_opa(obj, UiConstants::OPA_COVER, 0);
 
 	// Add observer for Theme changes
 	lv_subject_add_observer_obj(
@@ -25,7 +23,6 @@ static inline void apply_glass(lv_obj_t* obj, int32_t blur) {
 			ThemeConfig cfg = Themes::GetConfig(theme);
 			lv_obj_set_style_bg_color(target, cfg.surface, 0);
 			lv_obj_set_style_text_color(target, cfg.text_primary, 0);
-			lv_obj_set_style_image_recolor(target, cfg.text_primary, 0);
 		},
 		obj, nullptr
 	);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed ineffective lv_obj_set_style_image_recolor and lv_obj_set_style_image_recolor_opa calls from apply_glass (including in the theme observer). This removes no-op styling and minor overhead; no visual changes expected.

<sup>Written for commit 73212cb4f0581f23d269a8d582555ac32147941b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

