### PR TITLE
add settings button to quickaccess

### DIFF
--- a/main/core/ui/desktop/modules/quick_access_panel/QuickAccessPanel.cpp
+++ b/main/core/ui/desktop/modules/quick_access_panel/QuickAccessPanel.cpp
@@ -3,14 +3,16 @@
 #include "../../../theming/layout_constants/LayoutConstants.hpp"
 #include "../../../theming/theme_engine/ThemeEngine.hpp"
 #include "../../../theming/ui_constants/UiConstants.hpp"
-#include "core/apps/AppManager.hpp"
+
 #include "core/lv_obj.h"
 #include "core/lv_obj_pos.h"
 #include "core/lv_obj_style.h"
 #include "core/lv_obj_style_gen.h"
 #include "core/lv_observer.h"
 #include "core/system/display/DisplayManager.hpp"
+#include "core/system/focus/FocusManager.hpp"
 #include "core/system/theme/ThemeManager.hpp"
+#include "core/ui/desktop/window_manager/WindowManager.hpp"
 #include "core/ui/theming/themes/Themes.hpp"
 #include "display/lv_display.h"
 #include "draw/lv_draw_rect.h"
@@ -72,7 +74,9 @@ void QuickAccessPanel::create() {
 	lv_image_set_src(settings_icon, LV_SYMBOL_SETTINGS);
 	lv_obj_center(settings_icon);
 
-	lv_obj_add_event_cb(settings_btn, [](lv_event_t* e) { System::Apps::AppManager::getInstance().startApp("com.os.settings"); }, LV_EVENT_CLICKED, nullptr);
+	lv_obj_add_event_cb(settings_btn, [](lv_event_t* e) {
+		System::FocusManager::getInstance().dismissAllPanels();
+		WindowManager::getInstance().openApp("com.os.settings"); }, LV_EVENT_CLICKED, nullptr);
 
 	lv_obj_t* toggles_cont = lv_obj_create(m_panel);
 	lv_obj_remove_style_all(toggles_cont);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a header to the Quick Access panel with a Settings button that now reliably opens the Settings app and dismisses the panel. Switched the brightness slider icon to an eye for clearer meaning.

<sup>Written for commit 0b8b81121d671eb3d1f15471cb9f0f35199b8cb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

