### PR TITLE
fix: dynamically update QuickAccessPanel settings button text color based on theme changes

### DIFF
--- a/main/core/ui/desktop/modules/quick_access_panel/QuickAccessPanel.cpp
+++ b/main/core/ui/desktop/modules/quick_access_panel/QuickAccessPanel.cpp
@@ -78,6 +78,21 @@ void QuickAccessPanel::create() {
 		System::FocusManager::getInstance().dismissAllPanels();
 		WindowManager::getInstance().openApp("com.os.settings"); }, LV_EVENT_CLICKED, nullptr);
 
+	lv_obj_set_style_text_color(settings_btn, Themes::GetConfig(ThemeEngine::get_current_theme()).text_primary, 0);
+
+	lv_subject_add_observer_obj(
+		&System::ThemeManager::getInstance().getThemeSubject(),
+		[](lv_observer_t* observer, lv_subject_t* subject) {
+			lv_obj_t* btn = lv_observer_get_target_obj(observer);
+			if (btn) {
+				ThemeType theme = (ThemeType)lv_subject_get_int(subject);
+				ThemeConfig cfg = Themes::GetConfig(theme);
+				lv_obj_set_style_text_color(btn, cfg.text_primary, 0);
+			}
+		},
+		settings_btn, nullptr
+	);
+
 	lv_obj_t* toggles_cont = lv_obj_create(m_panel);
 	lv_obj_remove_style_all(toggles_cont);
 	lv_obj_set_size(toggles_cont, lv_pct(100), LV_SIZE_CONTENT);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the QuickAccessPanel Settings button text color to match the active theme and update live when the theme changes. Improves readability and theme consistency.

- **Bug Fixes**
  - Set initial text color from the current theme config during panel creation.
  - Added a theme subject observer to update the button’s text color on theme changes.

<sup>Written for commit 53a779fa7c32e8c54b420429720a4affc0f00ad1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

