### PR TITLE
feat: log SD card info on mount and move notification logic to onGuiInit

### DIFF
--- a/System/Source/services/SdCardService.cpp
+++ b/System/Source/services/SdCardService.cpp
@@ -64,12 +64,6 @@ bool SdCardService::onStart() {
 	const bool mounted = m_device->mount(flx::config::sdcard.mountPoint);
 	if (mounted) {
 		Log::info(TAG, "Mounted SD card via HAL (%s)", bus_type.data());
-		flx::core::Bundle data;
-		data.putString("title", "Storage");
-		data.putString("message", "SD Card mounted at " + getMountPoint());
-		data.putString("appName", "System");
-		data.putString("icon", "info");
-		flx::core::EventBus::getInstance().publish("system.notify", data);
 		flx::hal::sdcard::ISdCardDevice::CardInfo info;
 		if (m_device->getCardInfo(info)) {
 			Log::info(TAG, "SD Card Info: Size: %llu MB, Free: %llu MB, FS: %s", (unsigned long long)(info.totalBytes / (1024ULL * 1024ULL)), (unsigned long long)(info.freeBytes / (1024ULL * 1024ULL)), info.fsType.c_str());
@@ -81,7 +75,16 @@ bool SdCardService::onStart() {
 	return mounted;
 }
 
-void SdCardService::onGuiInit() {}
+void SdCardService::onGuiInit() {
+	if (isMounted()) {
+		flx::core::Bundle data;
+		data.putString("title", "Storage");
+		data.putString("message", "SD Card mounted at " + getMountPoint());
+		data.putString("appName", "System");
+		data.putString("icon", "info");
+		flx::core::EventBus::getInstance().publish("system.notify", data);
+	}
+}
 
 void SdCardService::onStop() {
 	if (m_device) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Log SD card capacity, free space, and filesystem on mount, and move the “SD Card mounted” `system.notify` to `onGuiInit`. This shows the notification only when the UI is ready and improves mount diagnostics.

<sup>Written for commit 5ab05aa119c8c78d26845c5a3cd5b37e832cc62b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

