### PR TITLE
feat: implement onResume to restore main settings view after pause

### DIFF
--- a/Applications/settings/SettingsApp.cpp
+++ b/Applications/settings/SettingsApp.cpp
@@ -123,6 +123,18 @@ void SettingsApp::onPause() {
 	m_pluginRefreshPending.store(false);
 }
 
+bool SettingsApp::onResume() {
+	if (m_container == nullptr) {
+		return true;
+	}
+
+	// onPause() deactivated the plugin (hiding its UI) but left
+	// m_mainList and m_searchTa hidden.  Restore the main settings view
+	// so the user doesn't see a blank white screen.
+	showMainSettings();
+	return true;
+}
+
 void SettingsApp::update() {
 	if (!m_pluginRefreshPending.exchange(false) || m_container == nullptr) {
 		return;

--- a/Applications/settings/SettingsApp.hpp
+++ b/Applications/settings/SettingsApp.hpp
@@ -26,6 +26,7 @@ public:
 
 	void createUI(void* parent) override;
 	void onPause() override;
+	bool onResume() override;
 	void onStop() override;
 	void update() override;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore the main Settings view on resume to prevent a blank white screen after pausing. Adds SettingsApp::onResume() to call showMainSettings when the container exists.

<sup>Written for commit c804363f7090fc37cdabaf3663a7c962e987384f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flxos-labs/flxos/pull/105?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

