### PR TITLE
docs: add link and preview image for the FlxOS web simulator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ FlxOS is a production-focused operating system architecture for ESP32-class devi
 ### 🎮 Web Simulator
 
 You can run the fully interactive FlxOS web simulator directly in your browser:
-👉 **[flxos-labs.github.io/#simulator](https://flxos-labs.github.io/#simulator)**
+👉 **[flxos-labs.vercel.app/#simulator](https://flxos-labs.vercel.app/#simulator)**
 
 > ⚠️ **Note:** This is a browser-based web simulator demonstrating the user interface and features of FlxOS, not the actual OS running on embedded microcontrollers.
 
-[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.github.io/#simulator)
+[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.vercel.app/#simulator)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ FlxOS is a production-focused operating system architecture for ESP32-class devi
   </tr>
 </table>
 
+### 🎮 Web Simulator
+
+You can run the fully interactive FlxOS web simulator directly in your browser:
+👉 **[flxos-labs.github.io/#simulator](https://flxos-labs.github.io/#simulator)**
+
+[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.github.io/#simulator)
+
 ---
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ FlxOS is a production-focused operating system architecture for ESP32-class devi
 You can run the fully interactive FlxOS web simulator directly in your browser:
 👉 **[flxos-labs.github.io/#simulator](https://flxos-labs.github.io/#simulator)**
 
+> ⚠️ **Note:** This is a browser-based web simulator demonstrating the user interface and features of FlxOS, not the actual OS running on embedded microcontrollers.
+
 [![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.github.io/#simulator)
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@
 
 FlxOS is a production-focused operating system architecture for ESP32-class devices. It combines a desktop-grade UI layer with a structured app and service model, enabling teams to build feature-rich products without ad hoc firmware growth.
 
+### 🎮 Web Simulator
+
+You can run the fully interactive FlxOS web simulator directly in your browser:
+👉 **[flxos-labs.github.io/#simulator](https://flxos-labs.github.io/#simulator)**
+
+[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.github.io/#simulator)
+
+---
+
 ### 🖼️ Product Preview
 
 <table align="center">
@@ -42,13 +51,6 @@ FlxOS is a production-focused operating system architecture for ESP32-class devi
     </td>
   </tr>
 </table>
-
-### 🎮 Web Simulator
-
-You can run the fully interactive FlxOS web simulator directly in your browser:
-👉 **[flxos-labs.github.io/#simulator](https://flxos-labs.github.io/#simulator)**
-
-[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.github.io/#simulator)
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Web Simulator section near the top of the README with a direct link, preview image, and a note that it’s a browser-based UI demo (not embedded FlxOS). The link now uses the Vercel URL https://flxos-labs.vercel.app/#simulator for quick launch from the README.

<sup>Written for commit deccf0cfe54f4eff7aab132b589204aeac44949b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flxos-labs/flxos/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

