### PR TITLE
docs: replace static simulator screenshot with demo gif link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can run the fully interactive FlxOS web simulator directly in your browser:
 
 > ⚠️ **Note:** This is a browser-based web simulator demonstrating the user interface and features of FlxOS, not the actual OS running on embedded microcontrollers.
 
-[![FlxOS Web Simulator](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/scr_20260312_161725_home_screen_with_dock_status_bar_wallpaper.png)](https://flxos-labs.vercel.app/#simulator)
+[![FlxOS Web Simulator Demo](https://raw.githubusercontent.com/flxos-labs/flxos-labs/main/public/images/screenshots/simulator_demo.gif)](https://flxos-labs.vercel.app/#simulator)
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the static simulator screenshot in the README with an animated demo GIF linking to the web simulator. This makes the interactivity clear and should boost clicks to the demo.

<sup>Written for commit 427149bdbceb557b2a466407ae4d786b79588f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flxos-labs/flxos/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

