### PR TITLE
docs: move feature list section above the product preview in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ You can run the fully interactive FlxOS web simulator directly in your browser:
 
 ---
 
+## ✨ Features
+
+- 🖥️ **Desktop Shell**: Window manager (dwindle layout), app launcher, status bar, notifications, quick access panel, and gesture navigation.
+- 📱 **App Framework**: Manifest-driven applications, intent routing, MIME handlers, and URL schemes.
+- ⚙️ **Service Lifecycle**: Dependency-aware startup, health checks, watchdog integration, and self-healing.
+- 🔌 **Hardware Portability**: Unified YAML-based hardware profile definition per board, supporting ESP32, S2, S3, C3, C6, H2, and P4 chips.
+- 📦 **Core Runtime**: EventBus, system preferences, diagnostic tools, and storage management utilities.
+
+---
+
 ### 🖼️ Product Preview
 
 <table align="center">
@@ -53,16 +63,6 @@ You can run the fully interactive FlxOS web simulator directly in your browser:
     </td>
   </tr>
 </table>
-
----
-
-## ✨ Features
-
-- 🖥️ **Desktop Shell**: Window manager (dwindle layout), app launcher, status bar, notifications, quick access panel, and gesture navigation.
-- 📱 **App Framework**: Manifest-driven applications, intent routing, MIME handlers, and URL schemes.
-- ⚙️ **Service Lifecycle**: Dependency-aware startup, health checks, watchdog integration, and self-healing.
-- 🔌 **Hardware Portability**: Unified YAML-based hardware profile definition per board, supporting ESP32, S2, S3, C3, C6, H2, and P4 chips.
-- 📦 **Core Runtime**: EventBus, system preferences, diagnostic tools, and storage management utilities.
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the Features section above the Product Preview in the README to highlight capabilities first. This makes the page easier to scan and helps new readers understand the product before seeing screenshots.

<sup>Written for commit 9a37287c49131f43e16ae6251159c9ddf1eb64ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flxos-labs/flxos/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

